### PR TITLE
Fix NSXT tests

### DIFF
--- a/capirca/lib/nsxt.py
+++ b/capirca/lib/nsxt.py
@@ -69,7 +69,7 @@ class Error(Exception):
   pass
 
 
-class UnsupportednsxtAccessListError(Error):
+class UnsupportedNsxtAccessListError(Error):
   """Raised when we're give a non named access list."""
   pass
 

--- a/tests/lib/nsxt_functtest.py
+++ b/tests/lib/nsxt_functtest.py
@@ -38,7 +38,7 @@ class NsxtFunctionalTest(absltest.TestCase):
         '--def',
         dest='definitions',
         help='definitions directory',
-        default='../def')
+        default='def')
     (FLAGS, args) = parser.parse_args([])
     self.defs = naming.Naming(FLAGS.definitions)
 
@@ -69,7 +69,7 @@ class NsxtFunctionalTest(absltest.TestCase):
 
     # check protocol
     protocol = rule["ip_protocol"]
-    self.assertEqual(protocol, '')
+    self.assertEqual(protocol, ['tcp'])
 
   def test_nsxt_nosectiondid(self):
     pol = policy.ParsePolicy(nsxt_mocktest.POLICY_NO_SECTION_ID, self.defs)
@@ -84,7 +84,7 @@ class NsxtFunctionalTest(absltest.TestCase):
 
     # check protocol
     protocol = rule["ip_protocol"]
-    self.assertEqual(protocol, '')
+    self.assertEqual(protocol, ['icmp'])
 
   def test_nsxt_nofiltertype(self):
     pol = policy.ParsePolicy(nsxt_mocktest.POLICY_NO_FILTERTYPE, self.defs)

--- a/tests/lib/nsxt_test.py
+++ b/tests/lib/nsxt_test.py
@@ -447,7 +447,7 @@ class TermTest(absltest.TestCase):
 
     # check protocol
     protocol = rule["ip_protocol"]
-    self.assertEqual(protocol, '')
+    self.assertEqual(protocol, ['udp'])
 
     # check notes
     notes = rule["notes"]
@@ -475,7 +475,7 @@ class TermTest(absltest.TestCase):
 
     # check protocol and sub protocol
     protocol = rule["ip_protocol"]
-    self.assertEqual(protocol, '')
+    self.assertEqual(protocol, ['icmpv6'])
 
   def testTranslatePolicy(self):
     """Test for Nsxt.test_TranslatePolicy."""
@@ -615,7 +615,7 @@ class TermTest(absltest.TestCase):
 
     # check protocol
     protocol = rule["ip_protocol"]
-    self.assertEqual(protocol, '')
+    self.assertEqual(protocol, ['udp'])
 
     # check notes
     notes = rule["notes"]
@@ -639,7 +639,7 @@ class TermTest(absltest.TestCase):
 
     # check protocol
     protocol = rule["ip_protocol"]
-    self.assertEqual(protocol, '')
+    self.assertEqual(protocol, ['icmp'])
 
   def testBuildTokens(self):
     self.naming.GetNetAddr.side_effect = [

--- a/tests/lib/nsxt_unittest.py
+++ b/tests/lib/nsxt_unittest.py
@@ -36,7 +36,7 @@ class TermTest(absltest.TestCase):
         '--def',
         dest='definitions',
         help='definitions directory',
-        default='../def')
+        default='def')
     (FLAGS, args) = parser.parse_args([])
     self.defs = naming.Naming(FLAGS.definitions)
 
@@ -86,7 +86,7 @@ class TermTest(absltest.TestCase):
 
     # check protocol
     protocol = rule_json["ip_protocol"]
-    self.assertEqual(protocol, "")
+    self.assertEqual(protocol, ['udp'])
 
     # check notes
     notes = rule_json["notes"]
@@ -127,7 +127,7 @@ class TermTest(absltest.TestCase):
 
     # check protocol
     protocol = rule["ip_protocol"]
-    self.assertEqual(protocol, "")
+    self.assertEqual(protocol, ['udp'])
 
     # check notes
     notes = rule["notes"]


### PR DESCRIPTION
Updated IP protocol which is now implemented, the path for definitions to match the new one and rename error object to be used by tests